### PR TITLE
improves validation and user report

### DIFF
--- a/src/inventory/Inventory.cpp
+++ b/src/inventory/Inventory.cpp
@@ -105,6 +105,17 @@ static void skipWhiteSpace (char **txt)
 	}
 }
 
+static void nullTrailWhiteSpace (char **text)
+{
+	size_t const len = strlen(*text);
+	char *txt = *text;
+	char *iter = &txt[len - 1];
+	while (*iter <= ' ') {
+		*iter = 0;
+		--iter;
+	}
+}
+
 static bool is_numeric (char **text)
 {
 	char *start = *text;
@@ -513,14 +524,16 @@ void code (void)
 {
 	char *code = *_code_ ;
 	skipWhiteSpace(&code);
-	printf("REFERENCE: %s", code);
+	nullTrailWhiteSpace(&code);
+	printf("REFERENCE: %s\n", code);
 }
 
 void info (void)
 {
 	char *info = *_info_ ;
 	skipWhiteSpace(&info);
-	printf("DESCRIPTION: %s", info);
+	nullTrailWhiteSpace(&info);
+	printf("DESCRIPTION: %s\n", info);
 }
 
 void size (void)

--- a/src/inventory/Inventory.cpp
+++ b/src/inventory/Inventory.cpp
@@ -511,12 +511,16 @@ void header (void)
 
 void code (void)
 {
-	printf("REFERENCE: %s", *_code_);
+	char *code = *_code_ ;
+	skipWhiteSpace(&code);
+	printf("REFERENCE: %s", code);
 }
 
 void info (void)
 {
-	printf("DESCRIPTION: %s", *_info_);
+	char *info = *_info_ ;
+	skipWhiteSpace(&info);
+	printf("DESCRIPTION: %s", info);
 }
 
 void size (void)

--- a/src/inventory/Inventory.cpp
+++ b/src/inventory/Inventory.cpp
@@ -100,7 +100,7 @@ static bool isNumber (char const c)
 
 static void skipWhiteSpace (char **txt)
 {
-	while (**txt && **txt <= ' ') {
+	while (**txt && **txt != '\n' && **txt <= ' ') {
 		++*txt;
 	}
 }

--- a/src/inventory/Inventory.cpp
+++ b/src/inventory/Inventory.cpp
@@ -113,6 +113,11 @@ static bool is_numeric (char **text)
 	}
 
 	skipWhiteSpace(text);
+	if (!**text || **text == '\n') {
+		*text = start;
+		return false;
+	}
+
 	char *iter = *text;
 	bool space = false;
 	while (*iter && *iter != '\n') {


### PR DESCRIPTION
- makes sure that `skipWhiteSpace` advances the iterator to either '\0' or '\n' in the absence of printable characters
- removes leading and trailing whitespace from the report to improve its aesthetics